### PR TITLE
Removed yaml-cpp

### DIFF
--- a/interbotix_sdk/CMakeLists.txt
+++ b/interbotix_sdk/CMakeLists.txt
@@ -81,7 +81,7 @@ generate_messages(
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS actionlib dynamixel_workbench_toolbox interbotix_descriptions message_runtime roscpp sensor_msgs std_msgs std_srvs trajectory_msgs urdf yaml-cpp
+  CATKIN_DEPENDS actionlib dynamixel_workbench_toolbox interbotix_descriptions message_runtime roscpp sensor_msgs std_msgs std_srvs trajectory_msgs urdf
 )
 
 ###########


### PR DESCRIPTION
`yaml-cpp` throws a build error as it's not a catkin package

![Screenshot from 2022-09-29 23-59-11](https://user-images.githubusercontent.com/40535193/193210093-7aeee37b-b8f1-4494-8b39-f5e395aadf42.png)

Removing `yaml-cpp` solves this error.
System: Ubuntu 18.04 with ROS melodic